### PR TITLE
Adjusted metrics collection to ensure old labels are never retained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ Some things to rememeber:
 
 # Changelog
 
+09-Dec-2020 (v47rc4)
+- ensure that prometheus does not keep older label names around for the application query - the human verion of this is really:
+  just count the app versions that are current, do not count "old" app versions that no longer apply.
+
 26-Nov-2020 (v47)
 - greatly improved unit test coverage on fwrest.py 
 - queries the fw server to decide which URLs should be used to fetch data - this is important beginning

--- a/extra_metrics/application.py
+++ b/extra_metrics/application.py
@@ -1,4 +1,5 @@
-from prometheus_client import Gauge
+from prometheus_client import REGISTRY
+from prometheus_client.metrics_core import GaugeMetricFamily
 
 import traceback
 import pkg_resources
@@ -11,9 +12,25 @@ from .fwrest import http_request_time_taken
 from .logs import logger
 
 
-app_version_count = Gauge('extra_metrics_application_version',
-    'a summary of how many devices are using a particular app & version',
-    ["query_name", "application_version", "query_id"])
+class ApplicationResultCollector(object):
+    def __init__(self):
+        self.app_results = []
+
+    def add_result(self, query_id, query_name, app_version, app_total):
+        self.app_results.append({
+            "id": str(query_id),
+            "query_name": query_name,
+            "app_version": app_version,
+            "total": app_total
+        })
+
+    def collect(self):
+        gauge = GaugeMetricFamily(name="extra_metrics_application_version",
+                                  documentation='a summary of how many devices are using a particular app & version',
+                                  labels=['query_name', 'application_version', 'query_id'])
+        for item in self.app_results:
+            gauge.add_metric([item['query_name'], item['app_version'], item["id"]], item["total"])
+        yield gauge
 
 
 class ApplicationUsageRollup:
@@ -52,6 +69,7 @@ class ApplicationQueryManager:
     def __init__(self, fw_query):
         self.fw_query = fw_query
         self.app_queries = {}
+        self.results_collector = None
 
     def is_query_valid(self, q_id):
         app_name = False
@@ -94,6 +112,7 @@ class ApplicationQueryManager:
         all_queries = self.fw_query.get_all_inventory_queries()
 
         self.app_queries = {}
+
         for q in all_queries:
             q_group = q["group"]
             q_id = q["id"]
@@ -118,6 +137,10 @@ class ApplicationQueryManager:
             logger.warning("The inventory group named 'Extra Metrics Queries - Apps' could not be found - not refreshing queries")
 
     def collect_application_query_results(self):
+        if self.results_collector is not None:
+            REGISTRY.unregister(self.results_collector)
+        self.results_collector = ApplicationResultCollector()
+
         for q_id, q in self.app_queries.items():
             r = ApplicationUsageRollup(q_id, ["Application_name", "Application_version"], "Client_device_id")
 
@@ -131,7 +154,10 @@ class ApplicationQueryManager:
                     version = result[1]
                     total = int(result[2])
                     logger.info(f"app query result for {name}, {version}, query_id: {r.query_id} = {total}")
-                    app_version_count.labels(name, version, r.query_id).set(total)
+                    self.results_collector.add_result(r.query_id, name, version, total)
+
             except Exception as e:
                 logger.error(f"failed to do app query rollup on query id {q_id}, {e}")
                 traceback.print_exc(file=sys.stdout)
+
+        REGISTRY.register(self.results_collector)

--- a/extra_metrics/test/test_applications.py
+++ b/extra_metrics/test/test_applications.py
@@ -33,6 +33,18 @@ class ExtraMetricsTestCase(unittest.TestCase):
                                                   "query_id": "105"})
         self.assertEqual(1, after)
 
+    def test_app_manager_collecting_twice_doesnt_cause_totals_to_double(self):
+        app_mgr = ApplicationQueryManager(self.fw_query)
+        app_mgr.validate_query_definitions()
+
+        app_mgr.collect_application_query_results()
+        app_mgr.collect_application_query_results()
+
+        after = REGISTRY.get_sample_value('extra_metrics_application_version',
+                                          labels={"query_name": "Adobe Acrobat Reader Win",
+                                                  "application_version": "12.1", "query_id": "101"})
+        self.assertEqual(1, after)
+
     def test_app_manager_query_validation(self):
         app_mgr = ApplicationQueryManager(self.fw_query)
         self.assertEqual(len(app_mgr.app_queries), 0)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="filewave-extra-metrics",
-    version="1.0.47rc2",
+    version="1.0.47rc4",
     author="John Clayton",
     author_email="johnc@filewave.com",
     description="An additional module that exposes s/ware patching and metrics information to the built in FileWave dashboard",


### PR DESCRIPTION
Made sure the metrics samples don't have old data - the Applications queries use a new technique to collect the samples where the end effect is that older versions of apps don't get counted.; this is very good because as you upgrade apps, you don't want to count the older version any more - you want to only count the latest/current version.